### PR TITLE
Fix int to ptr conversion for x64

### DIFF
--- a/src/game/server/NextBot/NextBotContextualQueryInterface.h
+++ b/src/game/server/NextBot/NextBotContextualQueryInterface.h
@@ -25,8 +25,11 @@ enum QueryResultType
 };
 
 // Can pass this into IContextualQuery::IsHindrance to see if any hindrance is ever possible
+#ifdef NEO
+#define IS_ANY_HINDRANCE_POSSIBLE ( (CBaseEntity*)(INT_TO_POINTER(UINTPTR_MAX)) )
+#else
 #define IS_ANY_HINDRANCE_POSSIBLE	( (CBaseEntity*)0xFFFFFFFF )
-
+#endif
 
 //----------------------------------------------------------------------------------------------------------------
 /**

--- a/src/game/server/NextBot/Path/NextBotPathFollow.cpp
+++ b/src/game/server/NextBot/Path/NextBotPathFollow.cpp
@@ -796,7 +796,7 @@ CBaseEntity *PathFollower::FindBlocker( INextBot *bot )
 
 	// if we don't care about hindrances, don't do the expensive tests
 #ifdef NEO
-	AssertOnce(POINTER_TO_INT(IS_ANY_HINDRANCE_POSSIBLE) == -1);
+	AssertOnce(uintp(IS_ANY_HINDRANCE_POSSIBLE) == uintp(-1));
 #endif
 	if ( think->IsHindrance( bot, IS_ANY_HINDRANCE_POSSIBLE ) != ANSWER_YES )
 		return NULL;

--- a/src/game/server/NextBot/Path/NextBotPathFollow.cpp
+++ b/src/game/server/NextBot/Path/NextBotPathFollow.cpp
@@ -795,6 +795,9 @@ CBaseEntity *PathFollower::FindBlocker( INextBot *bot )
 	IIntention *think = bot->GetIntentionInterface();
 
 	// if we don't care about hindrances, don't do the expensive tests
+#ifdef NEO
+	AssertOnce(POINTER_TO_INT(IS_ANY_HINDRANCE_POSSIBLE) == -1);
+#endif
 	if ( think->IsHindrance( bot, IS_ANY_HINDRANCE_POSSIBLE ) != ANSWER_YES )
 		return NULL;
 


### PR DESCRIPTION
Int to pointer conversion is implementation-defined. Use the platform-specific max value, because else we can get a value of `0x00000000FFFFFFFF` when we wanted `0xFFFFFFFFFFFFFFFF` if extending a 32-bit integer to a 64-bit pointer.

Also fixes the compiler warning about this conversion for both Windows & Linux.